### PR TITLE
Possible DDos: Refactor api/cron to a cli command

### DIFF
--- a/dudel/views.py
+++ b/dudel/views.py
@@ -37,37 +37,6 @@ def get_locale():
         return request.accept_languages.best_match(supported_languages)
 
 
-@app.route("/api/cron")
-def cron():
-    # This view should execute some regular tasks to be called by a cronjob, e.g.
-    # by simply curl-ing "/api/cron"
-
-    # Update LDAP groups
-    from dudel.plugins.ldapauth import ldap_connector
-
-    def generate():
-        try:
-            ldap_connector.update_users()
-            yield "updated LDAP users\n"
-        except Exception, e:
-            yield "error updating LDAP users: %s\n" % str(e)
-
-        try:
-            ldap_connector.update_groups()
-            yield "updated LDAP groups\n"
-        except Exception, e:
-            yield "error updating LDAP groups: %s\n" % str(e)
-
-        for poll in Poll.query.filter_by(deleted=False).all():
-            if poll.should_auto_delete:
-                poll.deleted = True
-                yield "auto-deleted poll: %s\n" % poll.title
-
-        db.session.commit()
-
-    return Response(generate(), mimetype="text/plain")
-
-
 @app.route("/api/members")
 @login_required
 def members():

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,36 @@
 #!/usr/bin/env python2
-from dudel import manager
+from __future__ import print_function
+import sys
+from dudel import manager, db
+from dudel.models import Poll
+
+
+@manager.command
+def cron():
+    # This view should execute some regular tasks to be called by a cronjob, e.g.
+    # by simply curl-ing "/api/cron"
+
+    # Update LDAP groups
+    from dudel.plugins.ldapauth import ldap_connector
+
+    try:
+        ldap_connector.update_users()
+        print("updated LDAP users\n")
+    except Exception, e:
+        print("error updating LDAP users: %s\n" % str(e), file=sys.stderr)
+
+    try:
+        ldap_connector.update_groups()
+        print("updated LDAP groups\n")
+    except Exception, e:
+        print("error updating LDAP groups: %s\n" % str(e), file=sys.stderr)
+
+    for poll in Poll.query.filter_by(deleted=False).all():
+        if poll.should_auto_delete:
+            poll.deleted = True
+            print("auto-deleted poll: %s\n" % poll.title)
+
+    db.session.commit()
 
 if __name__ == '__main__':
     manager.run()

--- a/manage.py
+++ b/manage.py
@@ -1,29 +1,32 @@
 #!/usr/bin/env python2
 from __future__ import print_function
 import sys
-from dudel import manager, db
+from dudel import manager, db, app
 from dudel.models import Poll
 
 
 @manager.command
 def cron():
-    # This view should execute some regular tasks to be called by a cronjob, e.g.
-    # by simply curl-ing "/api/cron"
+    """
+    This view should execute some regular tasks to be called by a cronjob, e.g.
+    by simply calling "./manage.py cron"
+    """
 
-    # Update LDAP groups
-    from dudel.plugins.ldapauth import ldap_connector
+    if "ldap" in app.config['LOGIN_PROVIDERS']:
+        # Update LDAP only if it is enabled
+        from dudel.plugins.ldapauth import ldap_connector
 
-    try:
-        ldap_connector.update_users()
-        print("updated LDAP users\n")
-    except Exception, e:
-        print("error updating LDAP users: %s\n" % str(e), file=sys.stderr)
+        try:
+            ldap_connector.update_users()
+            print("updated LDAP users\n")
+        except Exception, e:
+            print("error updating LDAP users: %s\n" % str(e), file=sys.stderr)
 
-    try:
-        ldap_connector.update_groups()
-        print("updated LDAP groups\n")
-    except Exception, e:
-        print("error updating LDAP groups: %s\n" % str(e), file=sys.stderr)
+        try:
+            ldap_connector.update_groups()
+            print("updated LDAP groups\n")
+        except Exception, e:
+            print("error updating LDAP groups: %s\n" % str(e), file=sys.stderr)
 
     for poll in Poll.query.filter_by(deleted=False).all():
         if poll.should_auto_delete:


### PR DESCRIPTION
the api/cron endpoint is working relatively long, so it is a good candidate for a DDos. I think it is not necessary to have the Cron called over HTTP. Now you can call it via ./manage.py corn. 

Plus side: errors getting print to stderr, normal operation to stdout, so you can write stdout to a file and get the errors via mail.