### PR TITLE
dudel/models/poll.py: fix show_summary detection

### DIFF
--- a/dudel/models/poll.py
+++ b/dudel/models/poll.py
@@ -177,7 +177,7 @@ class Poll(db.Model):
 
     def show_summary(self, user):
         return self.user_can_administrate(user) \
-            or self.show_votes \
+            or self.show_votes(user) \
             or self.show_results == "summary" \
             or (self.show_results == "summary_after_vote" and self.is_expired)
 


### PR DESCRIPTION
the show_summary check only checked the boolean value of show_votes (which is
true, because the function exists), but not whether the current user is
actually allowed to see the votes