### PR TITLE
dudel.wsgi: correctly find real path of the rest of the code

### DIFF
--- a/dudel.wsgi
+++ b/dudel.wsgi
@@ -1,7 +1,10 @@
 #!/usr/bin/env python2
 import sys, os, datetime
 
-path = os.path.dirname(os.path.abspath(__file__))
+# this file might be symlinked somewhere (e.g. apache2 needs .wsgi files
+# in an accessible location like webroot), so we need to find the actual
+# path for the rest of the code
+path = os.path.dirname(os.path.realpath(__file__))
 
 # Activate the virtual environment to load the library.
 # TODO: change this if your virtual environment is not located at ./env


### PR DESCRIPTION
previously, the abspath() of server.wsgi was added to the python import
path. abspath() however only cleans up the given path string, with no
filesystem interaction like resolving symlinks etc.

some webservers (like apache2) require .wsgi files to be in an
accessible location (like webroot), where for security you might not
want to put your whole code, thus encouraging the use of symlinks.